### PR TITLE
feat: added a 'remove other keyboards' flag to the install script

### DIFF
--- a/scripts/install/completions.bash
+++ b/scripts/install/completions.bash
@@ -8,7 +8,7 @@ _x_install_script_completions() {
 
     
     # suggest flags if current word starts with -
-    local opts="-h --help -v --verbose -q --quiet -g --globally"
+    local opts="-h --help -v --verbose -q --quiet -g --globally -r --remove-others"
     COMPREPLY=( $(compgen -W "$opts" -- "$cur") )
     return 0
 }


### PR DESCRIPTION
This flag removes other keyboards from the install repository (either locally or globally). The point of this is that if you perform a fuzzy find in the repository, the other repositories will not clog up your search results.

This flag is enabled by default for installing locally, and disabled by default for installs that are performed globally.