### PR TITLE
feat(scripts): Added combined short flags support

### DIFF
--- a/scripts/flash/script.bash
+++ b/scripts/flash/script.bash
@@ -3,13 +3,21 @@
 set -e
 
 # Separates --option=value into '--option' and 'value'.
+# Also splits compact short options like '-abc' into '-a' '-b' '-c'.
 new_args=()
 while [[ $# -gt 0 ]]; do
     case "$1" in
-        -*=*)
+        -*=*)  # Handle --option=value
             key="${1%%=*}"
             val="${1#*=}"
             new_args+=("$key" "$val")
+            shift
+            ;;
+        -[!-]?*)  # Handle compact short options (e.g. -abc)
+            flags="${1#-}"
+            for ((i=0; i<${#flags}; i++)); do
+                new_args+=("-${flags:i:1}")
+            done
             shift
             ;;
         *)

--- a/scripts/install/script.bash
+++ b/scripts/install/script.bash
@@ -3,13 +3,21 @@
 set -e
 
 # Separates --option=value into '--option' and 'value'.
+# Also splits compact short options like '-abc' into '-a' '-b' '-c'.
 new_args=()
 while [[ $# -gt 0 ]]; do
     case "$1" in
-        -*=*)
+        -*=*)  # Handle --option=value
             key="${1%%=*}"
             val="${1#*=}"
             new_args+=("$key" "$val")
+            shift
+            ;;
+        -[!-]?*)  # Handle compact short options (e.g. -abc)
+            flags="${1#-}"
+            for ((i=0; i<${#flags}; i++)); do
+                new_args+=("-${flags:i:1}")
+            done
             shift
             ;;
         *)

--- a/scripts/watch/script.bash
+++ b/scripts/watch/script.bash
@@ -3,13 +3,21 @@
 set -e
 
 # Separates --option=value into '--option' and 'value'.
+# Also splits compact short options like '-abc' into '-a' '-b' '-c'.
 new_args=()
 while [[ $# -gt 0 ]]; do
     case "$1" in
-        -*=*)
+        -*=*)  # Handle --option=value
             key="${1%%=*}"
             val="${1#*=}"
             new_args+=("$key" "$val")
+            shift
+            ;;
+        -[!-]?*)  # Handle compact short options (e.g. -abc)
+            flags="${1#-}"
+            for ((i=0; i<${#flags}; i++)); do
+                new_args+=("-${flags:i:1}")
+            done
             shift
             ;;
         *)


### PR DESCRIPTION
So before if you provide the flags like this: `script -abc` instead of `script -a -b -c` it would complain, saying it does not know the flag: `-abc`. Now before parsing it split the short flags into their separated versions. So now `script -abc` is equivalent to `script -a -b -c`.