### PR TITLE
fix: pre-commit typos misconfiguration

### DIFF
--- a/.config/pre-commit.nix
+++ b/.config/pre-commit.nix
@@ -104,12 +104,6 @@
     # Checks for spelling errors in both the files and commit messages.
     typos = {
       enable = true;
-      settings.configuration = ''
-        [files]
-        extend-exclude = [ 
-          "CHANGELOG.md"
-        ]
-      '';
       stages = [
         "pre-commit"
         "commit-msg"


### PR DESCRIPTION
Typos had an extra setting that does not exist. Leading to an error.