### PR TITLE
chore: use USB `vid` and `pid` gifted from `pidcodes`

### DIFF
--- a/src/keyboard.json
+++ b/src/keyboard.json
@@ -71,7 +71,7 @@
 
     "usb": {
         "device_version": "2.0.0",
-        "pid": "0x0000",
-        "vid": "0xFEED"
+        "pid": "0xBCBC",
+        "vid": "0x1209"
     }
 }


### PR DESCRIPTION
As of merging pidcodes/pidcodes.github.com#1117 I now "own" `pid` `0xBCBC` from `vid` `0x1209` for the Snowflake V2 firmware development. Thank you guys over at `pidcodes` so much for the `pid` code!